### PR TITLE
Add activity feed API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

This PR introduces a new 'server.js' file for the Graphite Demo project.

### What changed?

A new 'server.js' file has been added to the Graphite-Demo project. This file sets up an Express.js server and initializes an endpoint '/feed' which serves a hardcoded mock of an activity feed data.

### How to test?

1. Navigate to the Graphite-Demo directory
2. Run 'node server.js' command in your terminal
3. Navigate to 'http://localhost:3000/feed' on your browser to see the served activity feed.

### Why make this change?

This change is made to provide a backend server for the Graphite Demo project. The server can serve activity feed data which the frontend client can consume. This introduces more complexity into the project and can be used to simulate a more real-world scenario.

---

